### PR TITLE
Set TF1 parameter values in FunctionPlot.create_tf1

### DIFF
--- a/HarryPlotter/python/analysis_modules/functionplot.py
+++ b/HarryPlotter/python/analysis_modules/functionplot.py
@@ -114,7 +114,9 @@ class FunctionPlot(analysisbase.AnalysisBase):
 		formula_name = ("function_" + nick).format(hashlib.md5("_".join([str(function), str(x_min), str(x_max),
 		                                                                str(start_parameters), str(nick), 
 		                                                                str(root_histogram.GetName() if root_histogram != None else "")])).hexdigest())
-		return ROOT.TF1(formula_name, function, x_min, x_max)
+		ret_tf1 = ROOT.TF1(formula_name, function, x_min, x_max)
+		ret_tf1.SetParameters(*start_parameters)
+		return ret_tf1
 
 	@staticmethod
 	def do_rootfit(function, x_min, x_max, start_parameters, nick="", root_histogram=None):


### PR DESCRIPTION
Just ran into this bug while trying to plot a TGraph and its associated TF1 function with HarryPlotter _without doing a fit_.

Passing `--function-parameters` without `--function-fit` doesn't initialize the parameters with the user-specified values, but uses the ROOT defaults instead. This leads to the wrong function being plotted.

This could be fixed by an extra call to `TF1::SetParameters`
